### PR TITLE
add `defer` option to defer non-critical CSS loading

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -20,7 +20,8 @@ const help = [
     '   -m, --minify    Minify the styles before inlining (default)',
     '   -e, --extract   Remove the inlined styles from any stylesheets referenced in the HTML',
     '   -b, --base      Is used when extracting styles to find the files references by `href` attributes',
-    '   -s, --selector  Optionally defines the element used by loadCSS as a reference for inlining'
+    '   -s, --selector  Optionally defines the element used by loadCSS as a reference for inlining',
+    '   -d, --defer     Defer loading styles until DOMContentLoaded event',
 ];
 
 const cli = meow({
@@ -33,7 +34,8 @@ const cli = meow({
         m: 'minify',
         b: 'base',
         e: 'extract',
-        s: 'selector'
+        s: 'selector',
+        d: 'defer'
     }
 });
 

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function getScript(defer) {
             item.setAttribute('media', 'all');
         });
     };
-    const deferString = `document.addEventListener('DOMContentLoaded', ${deferFunction.toString()});`;
+    const deferString = `window.requestAnimationFrame(${deferFunction.toString()});`;
     const loadCSS = read(loadCssMain) +
         read(path.join(loadCssBase, 'cssrelpreload.js')) +
         (defer ? deferString : '');


### PR DESCRIPTION
When enabled, the `defer` option defers loading non-critical CSS until after DOMContentLoaded event, allowing other critical resources to be loaded first.

Even when non-critical CSS loads asynchronously, using the link-preload resource hint causes the non-critical CSS to load with highest priority, delaying other lower-priority resources on the critical-rendering path (images, scripts, etc).

With `defer`, the non-critical CSS link-preload tags are marked with an additional `media=only x` attribute, which will prevent them from loading immediately. When the added `DOMContentLoaded` listener is fired, the media queries will be set to `all` and they will begin loading normally.