### PR TITLE
Use caret operator for normalize-newline

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "jsdom": "^15.1.1",
     "lodash": "^4.17.15",
     "meow": "^5.0.0",
-    "normalize-newline": "3.0.0",
+    "normalize-newline": "^3.0.0",
     "postcss": "^7.0.17",
     "postcss-discard": "^0.3.0",
     "prettier": "^1.18.2",


### PR DESCRIPTION
No functional change, but it's better in case there's a patch version out in the future.