### PR TITLE
Remove resolve dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "postcss-discard": "^0.3.2",
     "prettier": "^1.18.2",
     "reaver": "^2.0.0",
-    "resolve": "^1.12.0",
     "slash": "^3.0.0",
     "uglify-js": "^3.6.4"
   },

--- a/src/dom.js
+++ b/src/dom.js
@@ -3,10 +3,11 @@
 const fs = require('fs');
 const path = require('path');
 const {JSDOM} = require('jsdom');
-const resolve = require('resolve');
 const detectIndent = require('detect-indent');
 const flatten = require('lodash/flatten');
 const UglifyJS = require('uglify-js');
+
+const loadCssMain = require.resolve('fg-loadcss');
 
 /**
  * Get loadcss + cssrelpreload script
@@ -14,9 +15,7 @@ const UglifyJS = require('uglify-js');
  * @returns {string} Minified loadcss script
  */
 function getScript() {
-  const loadCssMain = resolve.sync('fg-loadcss');
-  const loadCssBase = path.dirname(loadCssMain);
-  const loadCSS = fs.readFileSync(path.join(loadCssBase, 'cssrelpreload.js'), 'utf8');
+  const loadCSS = fs.readFileSync(path.join(path.dirname(loadCssMain), 'cssrelpreload.js'), 'utf8');
 
   return UglifyJS.minify(loadCSS).code.trim();
 }


### PR DESCRIPTION
Not sure what this was supposed to fix/work around, but it seems using `require.resolve` is the same.

Unless you meant this to be async, which wasn't.

PR for 4.x coming next.